### PR TITLE
step22_admin

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -54,11 +54,9 @@ module Admin
     end
 
     def verify_admin!
-      if session[:user_id].present? && User.find_by(id: session[:user_id]).admin?
-        @current_user = User.find_by(id: session[:user_id])
-      else
-        redirect_to tasks_path, notice: t('message.require_admin')
-      end
+      return if current_user&.admin?
+
+      redirect_to tasks_path, notice: t('message.require_admin')
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,5 @@
 module Admin
   class UsersController < ApplicationController
-    before_action :verify_user!
     before_action :verify_admin!
     before_action :find_user, only: %i[edit update tasks destroy]
     def index
@@ -55,7 +54,11 @@ module Admin
     end
 
     def verify_admin!
-      redirect_to tasks_path, notice: t('message.require_admin') if User.find_by(id: session[:user_id]).role != 'admin'
+      if session[:user_id].present? && User.find_by(id: session[:user_id]).admin?
+        @current_user = User.find_by(id: session[:user_id])
+      else
+        redirect_to tasks_path, notice: t('message.require_admin')
+      end
     end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,7 @@
 module Admin
   class UsersController < ApplicationController
     before_action :verify_user!
+    before_action :verify_admin!
     before_action :find_user, only: %i[edit update tasks destroy]
     def index
       @users = User.all
@@ -35,8 +36,12 @@ module Admin
     end
 
     def destroy
-      @user.destroy
-      redirect_to admin_path, notice: t("message.delete_user_succeed")
+      flash.alert = if @user.destroy
+                      t("message.delete_user_succeed")
+                    else
+                      t('message.delete_user_failed')
+                    end
+      redirect_to admin_path
     end
 
     private
@@ -47,6 +52,10 @@ module Admin
 
     def find_user
       @user = User.find_by(id: params[:id])
+    end
+
+    def verify_admin!
+      redirect_to tasks_path, notice: t('message.require_admin') if User.find_by(id: session[:user_id]).role != 'admin'
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,9 @@
 class ApplicationController < ActionController::Base
   def verify_user!
-    if session[:user_id].present?
-      @current_user = User.find_by(id: session[:user_id])
-    else
-      redirect_to login_path
-    end
+    redirect_to login_path unless current_user
+  end
+
+  def current_user
+    @current_user ||= User.find_by(id: session[:user_id])
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,9 @@ class User < ApplicationRecord
   validates :name, uniqueness: true
   has_secure_password
   enum role: { normal: 0, admin: 1 }
-  before_destroy do
-    throw(:abort) if (User.where(role: 'admin').count == 1) && (role == 'admin')
+  before_destroy :check_last_admin
+  private
+  def check_last_admin
+    throw(:abort) if (User.admin.count == 1) && (admin?)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,8 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   validates :name, uniqueness: true
   has_secure_password
-  enum role: { normal: 0, manager: 1 }
+  enum role: { normal: 0, admin: 1 }
+  before_destroy do
+    throw(:abort) if (User.where(role: 'admin').count == 1) && (role == 'admin')
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,10 @@ class User < ApplicationRecord
   has_secure_password
   enum role: { normal: 0, admin: 1 }
   before_destroy :check_last_admin
+
   private
+
   def check_last_admin
-    throw(:abort) if (User.admin.count == 1) && (admin?)
+    throw(:abort) if (User.admin.count == 1) && admin?
   end
 end

--- a/config/locales/zh-TW/user.yml
+++ b/config/locales/zh-TW/user.yml
@@ -24,5 +24,3 @@ zh-TW:
     update_user_failed: '用戶更新失敗'
     create_user_succeed: '用戶新增成功'
     require_admin: '權限不足'
-
-

--- a/config/locales/zh-TW/user.yml
+++ b/config/locales/zh-TW/user.yml
@@ -11,7 +11,7 @@ zh-TW:
         role: "身份"
       user/role:
         normal: "一般使用者"
-        manager: "管理者"
+        admin: "管理者"
 
   message:
     input_error: "輸入錯誤"
@@ -19,8 +19,10 @@ zh-TW:
     signup_succeed: '成功註冊'
     signin_succeed: '成功登入'
     delete_user_succeed: '用戶刪除成功'
+    delete_user_failed: '用戶刪除失敗'
     update_user_succeed: '用戶更新成功'
     update_user_failed: '用戶更新失敗'
     create_user_succeed: '用戶新增成功'
+    require_admin: '權限不足'
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,6 @@ Rails.application.routes.draw do
   # ADMIN
   namespace :admin do
     get '/', to: 'users#index', as: '/'
-    # get 'user/:id/tasks', to: 'users#tasks', as: 'user_tasks'
     resources :users do
       member do
         get 'tasks'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,4 +15,4 @@ if Task.all.empty?
   FactoryBot.create_list(:task, 4, :complete)
 end
 
-FactoryBot.create(:user, :first) if User.all.empty?
+FactoryBot.create(:user, :normal) if User.all.empty?

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,13 +6,11 @@ FactoryBot.define do
 
     trait :normal do
       name { "NORMAL" }
-      password { 'password1' }
       role { 0 }
     end
 
     trait :admin do
       name { "ADMIN" }
-      password { 'password1' }
       role { 1 }
     end
   end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     role { Faker::Number.between(from: 0, to: 1) }
 
     trait :normal do
-      name { "NormalFirst" }
+      name { "NORMAL" }
       password { 'password1' }
       role { 0 }
     end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,10 +4,16 @@ FactoryBot.define do
     password { Faker::Coffee.variety }
     role { Faker::Number.between(from: 0, to: 1) }
 
-    trait :first do
+    trait :normal do
       name { "NormalFirst" }
       password { 'password1' }
       role { 0 }
+    end
+
+    trait :admin do
+      name { "ADMIN" }
+      password { 'password1' }
+      role { 1 }
     end
   end
 end

--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'faker'
 
 RSpec.describe 'Admin Users', type: :feature do
-  let!(:user) { create(:user, name: 'ADMIN') }
+  let!(:user) { create(:user, :admin) }
   let(:normal) { User.human_attribute_name("role.normal") }
   let(:button_signout) { I18n.t('signout') }
 
@@ -61,6 +61,7 @@ RSpec.describe 'Admin Users', type: :feature do
       refresh
     end
 
+    it { expect(find("tbody tr:nth-child(1) #name")).to have_content('ADMIN') }
     it { expect(find("tbody tr:nth-child(2) #name")).to have_content('DELETE') }
 
     context "when click delete button" do
@@ -68,6 +69,14 @@ RSpec.describe 'Admin Users', type: :feature do
         find("tbody tr:nth-child(2) #delete").click
         expect(page).to have_content(I18n.t('message.delete_user_succeed'))
         expect(page).not_to have_content('DELETE')
+      end
+    end
+
+    context "when delete last admin button" do
+      it do
+        find("tbody tr:nth-child(1) #delete").click
+        expect(page).to have_content(I18n.t('message.delete_user_failed'))
+        expect(page).to have_content('ADMIN')
       end
     end
   end
@@ -88,6 +97,23 @@ RSpec.describe 'Admin Users', type: :feature do
         find("tbody tr:nth-child(2) #tasks").click
         refresh
         expect(page).to have_content('NEWTASK')
+      end
+    end
+  end
+
+  describe 'verify admin' do
+    let!(:normal_user) { create(:user, :normal) }
+
+    before do
+      user_login(normal_user)
+      visit tasks_path
+    end
+
+    context "when user not admin" do
+      it do
+        find('#tab_admin').click
+        refresh
+        expect(page).to have_content(I18n.t('message.require_admin'))
       end
     end
   end

--- a/spec/features/admin_user_spec.rb
+++ b/spec/features/admin_user_spec.rb
@@ -57,18 +57,18 @@ RSpec.describe 'Admin Users', type: :feature do
 
   describe 'delete user' do
     before do
-      create(:user, name: 'DELETE')
+      create(:user, :normal)
       refresh
     end
 
     it { expect(find("tbody tr:nth-child(1) #name")).to have_content('ADMIN') }
-    it { expect(find("tbody tr:nth-child(2) #name")).to have_content('DELETE') }
+    it { expect(find("tbody tr:nth-child(2) #name")).to have_content('NORMAL') }
 
     context "when click delete button" do
       it do
         find("tbody tr:nth-child(2) #delete").click
         expect(page).to have_content(I18n.t('message.delete_user_succeed'))
-        expect(page).not_to have_content('DELETE')
+        expect(page).not_to have_content('NORMAL')
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,13 +6,12 @@ RSpec.describe User, type: :model do
   end
 
   describe 'Before_destroy' do
+    subject { admin.destroy }
+
     let!(:admin) { create(:user, :admin) }
 
     context 'when delete last admin' do
-      it do
-        admin.destroy
-        expect(described_class.count).to eq 1
-      end
+      it { is_expected.to be_falsy }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,4 +4,15 @@ RSpec.describe User, type: :model do
   describe 'Association' do
     it { is_expected.to have_many(:tasks).dependent(:destroy) }
   end
+
+  describe 'Before_destroy' do
+    let!(:admin) { create(:user, :admin) }
+
+    context 'when delete last admin' do
+      it do
+        admin.destroy
+        expect(described_class.count).to eq 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
- 將使用者分為管理員和一般使用者
- 請改成只有管理員可以存取使用者管理頁面
- 若一般使用者存取管理頁面時，需提示權限不足訊息無法存取，並轉向適當頁面
- 能在使用者管理頁面新增角色
- 管理者只剩下一個人時，不能再被刪除
- 利用 model 的 callback 實做